### PR TITLE
Improvement: Adding information of duplicate ids to value table

### DIFF
--- a/magma-datasource-csv/src/main/java/org/obiba/magma/datasource/csv/CsvValueTable.java
+++ b/magma-datasource-csv/src/main/java/org/obiba/magma/datasource/csv/CsvValueTable.java
@@ -91,6 +91,8 @@ public class CsvValueTable extends AbstractValueTable implements Initialisable, 
 
   private final CsvTimestamps timestamps;
 
+  private int duplicateIdCount = 0;
+
   public CsvValueTable(Datasource datasource, String name, File dataFile, String entityType) {
     this(datasource, name, null, dataFile, entityType);
   }
@@ -264,7 +266,8 @@ public class CsvValueTable extends AbstractValueTable implements Initialisable, 
   }
 
   private void initialiseData() throws IOException {
-    buildDataLineIndex();
+    Map<Integer, CsvIndexEntry> map = buildDataLineIndex();
+    this.duplicateIdCount = map.size() - entityIndex.size();
   }
 
   @NotNull
@@ -670,6 +673,10 @@ public class CsvValueTable extends AbstractValueTable implements Initialisable, 
       }
     }
     return missingVariables;
+  }
+
+  public int getDuplicateIdCount() {
+    return duplicateIdCount;
   }
 
 }


### PR DESCRIPTION
Our customer requested a warning when a CSV file has 'duplicate ids'.
This basically means the number of rows that will be supressed in the same file, because they relate to the same entiry (same id).
The backbone for this is in class CsvValueTable, hence this Pull Request.
